### PR TITLE
Separate ENA timesheet entries from totals

### DIFF
--- a/src/main/java/com/ena/timesheet/controller/UploadEnaTimesheet.java
+++ b/src/main/java/com/ena/timesheet/controller/UploadEnaTimesheet.java
@@ -30,7 +30,7 @@ public class UploadEnaTimesheet {
             //System.out.println("Controller:Upload " + dateStr + ", " + file.getOriginalFilename() + ", " + file.getSize() + " bytes");
             LocalDate tsMonth = LocalDate.parse(dateStr, formatter);
             EnaTimesheet enaTimesheet = new EnaTimesheet(tsMonth, inputStream);
-            List<EnaTsEntry> bdws = enaTimesheet.getEntries();
+            List<EnaTsEntry> bdws = enaTimesheet.getEntriesWithTotals();
             List<EnaTsProjectEntry> bps = enaTimesheet.getProjectEntries();
             model.addAttribute("invoiceMonth", mmyyFmt.format(tsMonth));
             model.addAttribute("invoiceDate", mdyFmt.format(LocalDate.now()));

--- a/src/main/java/com/ena/timesheet/ena/EnaTimesheet.java
+++ b/src/main/java/com/ena/timesheet/ena/EnaTimesheet.java
@@ -17,15 +17,28 @@ public class EnaTimesheet {
         List<EnaTsEntry> inputEntries = parseEntries(inputStream, sheetIndex);
         sortByDayProjectId(inputEntries);
         reindexEntries(inputEntries);
-        List<EnaTsEntry> totalEntries = weeklyTotals(inputEntries);
         this.enaTsEntries.addAll(inputEntries);
-        this.enaTsEntries.addAll(totalEntries);
-        sortByEntryId(this.enaTsEntries);
         this.projectEntries.addAll(getProjectEntries(inputEntries));
+    }
+
+    /**
+     * Add pseudo-entries to a separate list of entries to represent the weekly totals,
+     * plus empty lines for invoice formatting.
+     */
+    public List<EnaTsEntry> getEntriesWithTotals() {
+        List<EnaTsEntry> entriesWithTotals = new ArrayList<>();
+        entriesWithTotals.addAll(enaTsEntries);
+        List<EnaTsEntry> totalEntries = weeklyTotals(enaTsEntries);
+        entriesWithTotals.addAll(totalEntries);
+        sortByEntryId(entriesWithTotals);
+        return entriesWithTotals;
     }
 
     private final LocalDate timesheetMonth;
 
+    /**
+     * Entries parsed from the ENA timesheet, without any totals.
+     */
     public List<EnaTsEntry> getEntries() {
         return enaTsEntries;
     }


### PR DESCRIPTION
Separate ENA timesheet entries from totals, in order to have a clean separation between model and view.